### PR TITLE
Modal Form for New Channels

### DIFF
--- a/src/App/index.js
+++ b/src/App/index.js
@@ -8,6 +8,16 @@ import './App.scss';
 
 function App() {
   const [user, setUser] = useState(null);
+  const [currentChannel, setCurrentChannel] = useState({
+    name: 'Default Channel'
+  });
+
+  const [channelArr, setChannelArr] = useState([
+    { name: 'Happy' },
+    { name: 'Dumpy' },
+    { name: 'Dopey' }
+  ]);
+
   useEffect(() => {
     firebase.auth().onAuthStateChanged((authed) => {
       if (authed) {
@@ -26,7 +36,11 @@ function App() {
   return (
     <div className='App'>
       <Router>
-        <NavBar user={user}/>
+        <NavBar user={user}
+          currentChannel={currentChannel}
+          setCurrentChannel={setCurrentChannel}
+          channelArr={channelArr}
+          setChannelArr={setChannelArr} />
         <Routes />
       </Router>
     </div>

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -13,9 +13,9 @@ function App() {
   });
 
   const [channelArr, setChannelArr] = useState([
-    { name: 'Happy' },
-    { name: 'Dumpy' },
-    { name: 'Dopey' }
+    { name: 'E14 Cohort ' },
+    { name: 'Channel #2' },
+    { name: 'Channel #3' }
   ]);
 
   useEffect(() => {

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -7,16 +7,29 @@ import {
   Button
 } from 'reactstrap';
 import { signInUser, signOutUser } from '../helpers/auth';
+import ModalContainer from './forms/ModalContainer';
+import ChannelList from '../views/ChannelList';
 
-export default function NavBar({ user }) {
+export default function NavBar({
+  user,
+  currentChannel,
+  setCurrentChannel,
+  channelArr
+}) {
   return (
     <div>
       <Navbar id="navBar" light expand="md">
           <Nav className="sideNav" navbar>
-            <ul>
+            <ul className='slackNav'>
               <li className="nav-item">
               <Link to="/">Slacker</Link>
               </li>
+              <li>
+                <ModalContainer
+                  currentChannel={currentChannel}
+                  setCurrentChannel={setCurrentChannel} />
+              </li>
+                <ChannelList channelArr={channelArr} />
                 {
                   user !== null
                   && <li>
@@ -35,5 +48,8 @@ export default function NavBar({ user }) {
 }
 
 NavBar.propTypes = {
-  user: PropTypes.any
+  user: PropTypes.any,
+  currentChannel: PropTypes.object,
+  setCurrentChannel: PropTypes.func,
+  channelArr: PropTypes.array
 };

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -29,7 +29,9 @@ export default function NavBar({
                   currentChannel={currentChannel}
                   setCurrentChannel={setCurrentChannel} />
               </li>
+              <ul className='channel-list'>
                 <ChannelList channelArr={channelArr} />
+              </ul>
                 {
                   user !== null
                   && <li>

--- a/src/components/forms/ChannelForm.js
+++ b/src/components/forms/ChannelForm.js
@@ -1,0 +1,61 @@
+import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  Form, FormGroup,
+  Label, Input
+
+} from 'reactstrap';
+
+const ChannelForm = ({
+  currentChannel,
+  setCurrentChannel,
+  setSubmitFunc,
+  modal,
+  setModal
+}) => {
+  const submitRef = useRef(null);
+  useEffect(() => {
+    setSubmitFunc(submitRef);
+  }, [submitRef.current]);
+
+  const handleInputChange = (e) => {
+    setCurrentChannel((prevState) => ({
+      ...prevState,
+      [e.target.name]: e.target.value
+    }));
+    console.warn(e.target.name);
+  };
+
+  const handleSubmit = () => {
+    console.warn('handleSubmit in ChannelForm');
+    setModal(!modal);
+    const channelObj = {
+      name: currentChannel.name
+    };
+    console.warn(channelObj);
+  };
+  submitRef.current = handleSubmit;
+
+  return (
+  <>
+    <Form onSubmit= {handleSubmit}>
+      <FormGroup>
+        <Label for='channelName'>Channel Name</Label>
+        <Input type='text' name='name' placeholder='Enter channel name'
+          value={currentChannel.name} onChange={handleInputChange}/>
+      </FormGroup>
+    </Form>
+  </>
+  );
+};
+
+ChannelForm.propTypes = {
+  currentChannel: PropTypes.object,
+  setCurrentChannel: PropTypes.func,
+  setSubmitFunc: PropTypes.func,
+  modal: PropTypes.bool,
+  setModal: PropTypes.func
+};
+
+export default ChannelForm;

--- a/src/components/forms/ChannelForm.js
+++ b/src/components/forms/ChannelForm.js
@@ -26,7 +26,6 @@ const ChannelForm = ({
       ...prevState,
       [e.target.name]: e.target.value
     }));
-    console.warn(e.target.name);
   };
 
   const handleSubmit = () => {

--- a/src/components/forms/ChannelForm.js
+++ b/src/components/forms/ChannelForm.js
@@ -40,7 +40,7 @@ const ChannelForm = ({
 
   return (
   <>
-    <Form onSubmit= {handleSubmit}>
+    <Form onSubmit={handleSubmit}>
       <FormGroup>
         <Label for='channelName'>Channel Name</Label>
         <Input type='text' name='name' placeholder='Enter channel name'

--- a/src/components/forms/ChannelForm.js
+++ b/src/components/forms/ChannelForm.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import {
@@ -8,19 +8,21 @@ import {
 } from 'reactstrap';
 
 const ChannelForm = ({
-  currentChannel,
-  setCurrentChannel,
   setSubmitFunc,
   modal,
   setModal
 }) => {
+  const [formChannel, setFormChannel] = useState({
+    name: ''
+  });
+
   const submitRef = useRef(null);
   useEffect(() => {
     setSubmitFunc(submitRef);
   }, [submitRef.current]);
 
   const handleInputChange = (e) => {
-    setCurrentChannel((prevState) => ({
+    setFormChannel((prevState) => ({
       ...prevState,
       [e.target.name]: e.target.value
     }));
@@ -31,7 +33,7 @@ const ChannelForm = ({
     console.warn('handleSubmit in ChannelForm');
     setModal(!modal);
     const channelObj = {
-      name: currentChannel.name
+      name: formChannel.name
     };
     console.warn(channelObj);
   };
@@ -43,7 +45,7 @@ const ChannelForm = ({
       <FormGroup>
         <Label for='channelName'>Channel Name</Label>
         <Input type='text' name='name' placeholder='Enter channel name'
-          value={currentChannel.name} onChange={handleInputChange}/>
+          value={formChannel.name} onChange={handleInputChange}/>
       </FormGroup>
     </Form>
   </>
@@ -51,8 +53,6 @@ const ChannelForm = ({
 };
 
 ChannelForm.propTypes = {
-  currentChannel: PropTypes.object,
-  setCurrentChannel: PropTypes.func,
   setSubmitFunc: PropTypes.func,
   modal: PropTypes.bool,
   setModal: PropTypes.func

--- a/src/components/forms/ModalContainer.js
+++ b/src/components/forms/ModalContainer.js
@@ -1,17 +1,13 @@
 // React boilerplate modal
 
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import {
   Button, Modal, ModalHeader,
   ModalBody, ModalFooter
 } from 'reactstrap';
 import ChannelForm from './ChannelForm';
 
-const ModalContainer = ({
-  currentChannel,
-  setCurrentChannel
-}) => {
+const ModalContainer = () => {
   const [submitFunc, setSubmitFunc] = useState();
   const submitForm = () => {
     if (submitFunc) {
@@ -29,7 +25,7 @@ const ModalContainer = ({
       <Modal isOpen={modal} toggle={toggle} className='channel-form-modal'>
         <ModalHeader toggle={toggle}>Add Channel</ModalHeader>
         <ModalBody>
-          <ChannelForm currentChannel={currentChannel} setCurrentChannel={setCurrentChannel}
+          <ChannelForm
             setSubmitFunc={setSubmitFunc}
             modal={modal} setModal={setModal} />
         </ModalBody>
@@ -40,11 +36,6 @@ const ModalContainer = ({
       </Modal>
     </div>
   );
-};
-
-ModalContainer.propTypes = {
-  currentChannel: PropTypes.object,
-  setCurrentChannel: PropTypes.func
 };
 
 export default ModalContainer;

--- a/src/components/forms/ModalContainer.js
+++ b/src/components/forms/ModalContainer.js
@@ -21,7 +21,7 @@ const ModalContainer = () => {
 
   return (
     <div className='modal-container'>
-      <li className='nav-item channel-create' onClick={toggle}>Add Channel</li>
+      <div className='nav-item channel-create' onClick={toggle}>Add Channel</div>
       <Modal isOpen={modal} toggle={toggle} className='channel-form-modal'>
         <ModalHeader toggle={toggle}>Add Channel</ModalHeader>
         <ModalBody>

--- a/src/components/forms/ModalContainer.js
+++ b/src/components/forms/ModalContainer.js
@@ -1,0 +1,50 @@
+// React boilerplate modal
+
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, Modal, ModalHeader,
+  ModalBody, ModalFooter
+} from 'reactstrap';
+import ChannelForm from './ChannelForm';
+
+const ModalContainer = ({
+  currentChannel,
+  setCurrentChannel
+}) => {
+  const [submitFunc, setSubmitFunc] = useState();
+  const submitForm = () => {
+    if (submitFunc) {
+      submitFunc.current();
+    }
+  };
+  const [modal, setModal] = useState(false);
+  const toggle = () => {
+    setModal(!modal);
+  };
+
+  return (
+    <div className='modal-container'>
+      <li className='nav-item channel-create' onClick={toggle}>Add Channel</li>
+      <Modal isOpen={modal} toggle={toggle} className='channel-form-modal'>
+        <ModalHeader toggle={toggle}>Add Channel</ModalHeader>
+        <ModalBody>
+          <ChannelForm currentChannel={currentChannel} setCurrentChannel={setCurrentChannel}
+            setSubmitFunc={setSubmitFunc}
+            modal={modal} setModal={setModal} />
+        </ModalBody>
+        <ModalFooter>
+          <Button color="primary" onClick={submitForm}>Submit</Button>{' '}
+          <Button color="secondary" onClick={toggle}>Cancel</Button>
+        </ModalFooter>
+      </Modal>
+    </div>
+  );
+};
+
+ModalContainer.propTypes = {
+  currentChannel: PropTypes.object,
+  setCurrentChannel: PropTypes.func
+};
+
+export default ModalContainer;

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@ import reportWebVitals from './reportWebVitals';
 firebase.initializeApp(firebaseConfig);
 
 ReactDOM.render(
-  <React.StrictMode>
+  <React.Fragment>
     <App />
-  </React.StrictMode>,
+  </React.Fragment>,
   document.getElementById('root')
 );
 

--- a/src/index.js
+++ b/src/index.js
@@ -10,9 +10,9 @@ import reportWebVitals from './reportWebVitals';
 firebase.initializeApp(firebaseConfig);
 
 ReactDOM.render(
-  <React.Fragment>
+  <React.StrictMode>
     <App />
-  </React.Fragment>,
+  </React.StrictMode>,
   document.getElementById('root')
 );
 

--- a/src/styles/_modalContainer.scss
+++ b/src/styles/_modalContainer.scss
@@ -1,0 +1,6 @@
+// _modalContainer.scss
+
+.modal-container li {
+  font-size: 18px;
+  cursor: pointer;
+}

--- a/src/styles/_modalContainer.scss
+++ b/src/styles/_modalContainer.scss
@@ -1,6 +1,11 @@
 // _modalContainer.scss
 
-.modal-container li {
+.modal-container {
   font-size: 18px;
   cursor: pointer;
+}
+
+.modal-container div.channel-create {
+  font-size: 20px;
+  padding-left: 0px;
 }

--- a/src/styles/_navbar.scss
+++ b/src/styles/_navbar.scss
@@ -7,7 +7,12 @@ ul.slackNav {
 ul.channel-list {
   padding-inline-start: 0px;
 }
+
 .channel-list {
   color: white;
   list-style-type: none;
+}
+
+.channel-list li {
+  cursor: pointer
 }

--- a/src/styles/_navbar.scss
+++ b/src/styles/_navbar.scss
@@ -3,3 +3,11 @@
 ul.slackNav {
   list-style-type: none;
 }
+
+ul.channel-list {
+  padding-inline-start: 0px;
+}
+.channel-list {
+  color: white;
+  list-style-type: none;
+}

--- a/src/styles/_navbar.scss
+++ b/src/styles/_navbar.scss
@@ -1,0 +1,5 @@
+// _navbar.scss
+
+ul.slackNav {
+  list-style-type: none;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,6 +1,8 @@
 // index.scss
 @import './variables';
 @import "~@fortawesome/fontawesome-free/css/all.min.css";
+@import './navbar';
+@import './modalContainer';
 
 body {
   background-color: $favColor;

--- a/src/views/ChannelList.js
+++ b/src/views/ChannelList.js
@@ -3,9 +3,16 @@
 
 import React from 'react';
 
-const ChannelList = ({ channelArr }) => (
-  channelArr.map((channel, key) => <li
-    className='channel-list' key={key}> {channel.name}</li>)
-);
+const ChannelList = ({ channelArr }) => {
+  const handleClick = (e) => {
+    console.warn(e.target.textContent);
+  };
+
+  return (
+    channelArr.map((channel, key) => <li
+      className='channel-list' key={key}
+      value="{channel.name}" onClick={handleClick}>{channel.name}</li>)
+  );
+};
 
 export default ChannelList;

--- a/src/views/ChannelList.js
+++ b/src/views/ChannelList.js
@@ -1,0 +1,11 @@
+// ChannelList.js
+// Displays within sidebar nav
+
+import React from 'react';
+
+const ChannelList = ({ channelArr }) => (
+  channelArr.map((channel, key) => <li
+    className='channel-list' key={key}> {channel.name}</li>)
+);
+
+export default ChannelList;


### PR DESCRIPTION
## Description
This change adds a modal form for inputting a new channel name.  The form contains an onSubmit skeleton function for adding channels when we have the api calls written.

The change also displays a list of clickable dummy channels in the vertical side navbar, using a hook with an array of channel objects

## Related Issue
https://github.com/GonzalesMatthew/chatty/issues/28
https://github.com/GonzalesMatthew/chatty/issues/21
https://github.com/GonzalesMatthew/chatty/issues/9

## Motivation and Context
We will need a way to add channels, and the group chose the modal format for this form.

## How Can This Be Tested?
Open the console in the inspector. Click 'Add Channel' in the sidebar. A modal form should appear.  Enter a channel name and select submit. You should see the channel name in an object in the console ( to be removed for production ).
Click on the three sample channels. You should see the channel name appear in the console ( to be removed for production ).

## Screenshots (if appropriate):
![ModalCapture](https://user-images.githubusercontent.com/51683901/118060747-17f00800-b359-11eb-8884-6518ac5be4b4.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
