### PR TITLE
Added Missing Function Call

### DIFF
--- a/src/helpers/data/channelData.js
+++ b/src/helpers/data/channelData.js
@@ -26,7 +26,7 @@ const createChannel = (channel) => new Promise((resolve, reject) => {
 const deleteChannel = (firebaseKey) => new Promise((resolve, reject) => {
   axios
     .delete(`${dbUrl}/channels/${firebaseKey}.json`)
-    .then(() => resolve(getChannels))
+    .then(() => resolve(getChannels()))
     .catch((error) => reject(error));
 });
 


### PR DESCRIPTION
## Description

Added missing parentheses to a function call.

## Related Issue

- #31 

## Motivation and Context

Resolve will now return channels instead of the `getChannels` function.

## How Can This Be Tested?

Look in changed files in Github.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
